### PR TITLE
Add unit tests for remaining toggle types.

### DIFF
--- a/src/FeatureToggleSolution/Tests/FeatureToggle.Tests/EnabledBetweenDatesFeatureToggleTests.cs
+++ b/src/FeatureToggleSolution/Tests/FeatureToggle.Tests/EnabledBetweenDatesFeatureToggleTests.cs
@@ -1,0 +1,122 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+
+namespace JasonRoberts.FeatureToggle.Tests
+{
+    [TestClass]
+    public class EnabledBetweenDatesFeatureToggleTests
+    {
+        [TestMethod]
+        public void ShouldDisableFeatureAfterToggleTimePeriod()
+        {
+            var expectedNow = DateTime.Now;
+            var expectedTimePeriod = new Tuple<DateTime, DateTime>(expectedNow.AddMilliseconds(-2),
+                                                                   expectedNow.AddMilliseconds(-1));
+
+            var fakeNowProvider = new Mock<INowDateAndTime>();
+
+            fakeNowProvider.SetupGet(x => x.Now).Returns(expectedNow);
+
+            var fakeToggleValueProvider = new Mock<ITimePeriodProvider>();
+
+            fakeToggleValueProvider.Setup(x => x.EvaluateTimePeriod(It.IsAny<EnabledBetweenDatesFeatureToggle>())).Returns(expectedTimePeriod);
+
+            var sut = new MyEnabledBetweenDatesFeatureToggle();
+            sut.NowProvider = fakeNowProvider.Object;
+            sut.ToggleValueProvider = fakeToggleValueProvider.Object;
+
+            Assert.IsFalse(sut.FeatureEnabled);
+        }
+
+        [TestMethod]
+        public void ShouldDisableFeatureBeforeToggleTimePeriod()
+        {
+            var expectedNow = DateTime.Now;
+            var expectedTimePeriod = new Tuple<DateTime, DateTime>(expectedNow.AddMilliseconds(1),
+                                                                   expectedNow.AddMilliseconds(2));
+
+            var fakeNowProvider = new Mock<INowDateAndTime>();
+
+            fakeNowProvider.SetupGet(x => x.Now).Returns(expectedNow);
+
+            var fakeToggleValueProvider = new Mock<ITimePeriodProvider>();
+
+            fakeToggleValueProvider.Setup(x => x.EvaluateTimePeriod(It.IsAny<EnabledBetweenDatesFeatureToggle>())).Returns(expectedTimePeriod);
+
+            var sut = new MyEnabledBetweenDatesFeatureToggle();
+            sut.NowProvider = fakeNowProvider.Object;
+            sut.ToggleValueProvider = fakeToggleValueProvider.Object;
+
+            Assert.IsFalse(sut.FeatureEnabled);
+        }
+
+        [TestMethod]
+        public void ShouldEnableFeatureDuringToggleTimePeriod()
+        {
+            var expectedNow = DateTime.Now;
+            var expectedTimePeriod = new Tuple<DateTime, DateTime>(expectedNow.AddMilliseconds(-1),
+                                                                   expectedNow.AddMilliseconds(1));
+
+            var fakeNowProvider = new Mock<INowDateAndTime>();
+
+            fakeNowProvider.SetupGet(x => x.Now).Returns(expectedNow);
+
+            var fakeToggleValueProvider = new Mock<ITimePeriodProvider>();
+
+            fakeToggleValueProvider.Setup(x => x.EvaluateTimePeriod(It.IsAny<EnabledBetweenDatesFeatureToggle>())).Returns(expectedTimePeriod);
+
+            var sut = new MyEnabledBetweenDatesFeatureToggle();
+            sut.NowProvider = fakeNowProvider.Object;
+            sut.ToggleValueProvider = fakeToggleValueProvider.Object;
+
+            Assert.IsTrue(sut.FeatureEnabled);
+        }
+
+        [TestMethod]
+        public void ShouldEnableFeatureOnEndOfToggleTimePeriod()
+        {
+            var expectedNow = DateTime.Now;
+            var expectedTimePeriod = new Tuple<DateTime, DateTime>(expectedNow.AddMilliseconds(-1),
+                                                                   expectedNow);
+
+            var fakeNowProvider = new Mock<INowDateAndTime>();
+
+            fakeNowProvider.SetupGet(x => x.Now).Returns(expectedNow);
+
+            var fakeToggleValueProvider = new Mock<ITimePeriodProvider>();
+
+            fakeToggleValueProvider.Setup(x => x.EvaluateTimePeriod(It.IsAny<EnabledBetweenDatesFeatureToggle>())).Returns(expectedTimePeriod);
+
+            var sut = new MyEnabledBetweenDatesFeatureToggle();
+            sut.NowProvider = fakeNowProvider.Object;
+            sut.ToggleValueProvider = fakeToggleValueProvider.Object;
+
+            Assert.IsTrue(sut.FeatureEnabled);
+        }
+
+        [TestMethod]
+        public void ShouldEnableFeatureOnStartOfToggleTimePeriod()
+        {
+            var expectedNow = DateTime.Now;
+            var expectedTimePeriod = new Tuple<DateTime, DateTime>(expectedNow,
+                                                                   expectedNow.AddMilliseconds(1));
+
+            var fakeNowProvider = new Mock<INowDateAndTime>();
+
+            fakeNowProvider.SetupGet(x => x.Now).Returns(expectedNow);
+
+            var fakeToggleValueProvider = new Mock<ITimePeriodProvider>();
+
+            fakeToggleValueProvider.Setup(x => x.EvaluateTimePeriod(It.IsAny<EnabledBetweenDatesFeatureToggle>())).Returns(expectedTimePeriod);
+
+            var sut = new MyEnabledBetweenDatesFeatureToggle();
+            sut.NowProvider = fakeNowProvider.Object;
+            sut.ToggleValueProvider = fakeToggleValueProvider.Object;
+
+            Assert.IsTrue(sut.FeatureEnabled);
+        }
+
+        private class MyEnabledBetweenDatesFeatureToggle : EnabledBetweenDatesFeatureToggle { }
+    }  
+}

--- a/src/FeatureToggleSolution/Tests/FeatureToggle.Tests/EnabledOnOrAfterDateFeatureToggleTests.cs
+++ b/src/FeatureToggleSolution/Tests/FeatureToggle.Tests/EnabledOnOrAfterDateFeatureToggleTests.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+
+namespace JasonRoberts.FeatureToggle.Tests
+{
+    [TestClass]
+    public class EnabledOnOrAfterDateFeatureToggleTests
+    {
+        [TestMethod]
+        public void ShouldDisableFeatureBeforeToggleDateTime()
+        {
+            var expectedNow = DateTime.Now;
+
+            var fakeNowProvider = new Mock<INowDateAndTime>();
+
+            fakeNowProvider.SetupGet(x => x.Now).Returns(expectedNow);
+
+            var fakeToggleValueProvider = new Mock<IDateTimeToggleValueProvider>();
+
+            fakeToggleValueProvider.Setup(x => x.EvaluateDateTimeToggleValue(It.IsAny<EnabledOnOrAfterDateFeatureToggle>())).Returns(expectedNow.AddMilliseconds(1));
+
+            var sut = new MyEnabledOnOrAfterDateFeatureToggle();
+            sut.NowProvider = fakeNowProvider.Object;
+            sut.ToggleValueProvider = fakeToggleValueProvider.Object;
+
+            Assert.IsFalse(sut.FeatureEnabled);
+        }
+
+        [TestMethod]
+        public void ShouldEnableFeatureAfterToggleDateTime()
+        {
+            var expectedNow = DateTime.Now;
+
+            var fakeNowProvider = new Mock<INowDateAndTime>();
+
+            fakeNowProvider.SetupGet(x => x.Now).Returns(expectedNow);
+
+            var fakeToggleValueProvider = new Mock<IDateTimeToggleValueProvider>();
+
+            fakeToggleValueProvider.Setup(x => x.EvaluateDateTimeToggleValue(It.IsAny<EnabledOnOrAfterDateFeatureToggle>())).Returns(expectedNow.AddMilliseconds(-1));
+
+            var sut = new MyEnabledOnOrAfterDateFeatureToggle();
+            sut.NowProvider = fakeNowProvider.Object;
+            sut.ToggleValueProvider = fakeToggleValueProvider.Object;
+
+            Assert.IsTrue(sut.FeatureEnabled);
+        }
+
+        [TestMethod]
+        public void ShouldEnableFeatureOnToggleDateTime()
+        {
+            var expectedNow = DateTime.Now;
+
+            var fakeNowProvider = new Mock<INowDateAndTime>();
+
+            fakeNowProvider.SetupGet(x => x.Now).Returns(expectedNow);
+
+            var fakeToggleValueProvider = new Mock<IDateTimeToggleValueProvider>();
+
+            fakeToggleValueProvider.Setup(x => x.EvaluateDateTimeToggleValue(It.IsAny<EnabledOnOrAfterDateFeatureToggle>())).Returns(expectedNow);
+
+            var sut = new MyEnabledOnOrAfterDateFeatureToggle();
+            sut.NowProvider = fakeNowProvider.Object;
+            sut.ToggleValueProvider = fakeToggleValueProvider.Object;
+
+            Assert.IsTrue(sut.FeatureEnabled);
+        }
+
+        private class MyEnabledOnOrAfterDateFeatureToggle : EnabledOnOrAfterDateFeatureToggle { }
+    }  
+}

--- a/src/FeatureToggleSolution/Tests/FeatureToggle.Tests/EnabledOnOrBeforeDateFeatureToggleTests.cs
+++ b/src/FeatureToggleSolution/Tests/FeatureToggle.Tests/EnabledOnOrBeforeDateFeatureToggleTests.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+
+namespace JasonRoberts.FeatureToggle.Tests
+{
+    [TestClass]
+    public class EnabledOnOrBeforeDateFeatureToggleTests
+    {
+        [TestMethod]
+        public void ShouldDisableFeatureAfterToggleDateTime()
+        {
+            var expectedNow = DateTime.Now;
+
+            var fakeNowProvider = new Mock<INowDateAndTime>();
+
+            fakeNowProvider.SetupGet(x => x.Now).Returns(expectedNow);
+
+            var fakeToggleValueProvider = new Mock<IDateTimeToggleValueProvider>();
+
+            fakeToggleValueProvider.Setup(x => x.EvaluateDateTimeToggleValue(It.IsAny<EnabledOnOrBeforeDateFeatureToggle>())).Returns(expectedNow.AddMilliseconds(-1));
+
+            var sut = new MyEnabledOnOrBeforeDateFeatureToggle();
+            sut.NowProvider = fakeNowProvider.Object;
+            sut.ToggleValueProvider = fakeToggleValueProvider.Object;
+
+            Assert.IsFalse(sut.FeatureEnabled);
+        }
+
+        [TestMethod]
+        public void ShouldEnableFeatureBeforeToggleDateTime()
+        {
+            var expectedNow = DateTime.Now;
+
+            var fakeNowProvider = new Mock<INowDateAndTime>();
+
+            fakeNowProvider.SetupGet(x => x.Now).Returns(expectedNow);
+
+            var fakeToggleValueProvider = new Mock<IDateTimeToggleValueProvider>();
+
+            fakeToggleValueProvider.Setup(x => x.EvaluateDateTimeToggleValue(It.IsAny<EnabledOnOrBeforeDateFeatureToggle>())).Returns(expectedNow.AddMilliseconds(1));
+
+            var sut = new MyEnabledOnOrBeforeDateFeatureToggle();
+            sut.NowProvider = fakeNowProvider.Object;
+            sut.ToggleValueProvider = fakeToggleValueProvider.Object;
+
+            Assert.IsTrue(sut.FeatureEnabled);
+        }
+
+        [TestMethod]
+        public void ShouldEnableFeatureOnToggleDateTime()
+        {
+            var expectedNow = DateTime.Now;
+
+            var fakeNowProvider = new Mock<INowDateAndTime>();
+
+            fakeNowProvider.SetupGet(x => x.Now).Returns(expectedNow);
+
+            var fakeToggleValueProvider = new Mock<IDateTimeToggleValueProvider>();
+
+            fakeToggleValueProvider.Setup(x => x.EvaluateDateTimeToggleValue(It.IsAny<EnabledOnOrBeforeDateFeatureToggle>())).Returns(expectedNow);
+
+            var sut = new MyEnabledOnOrBeforeDateFeatureToggle();
+            sut.NowProvider = fakeNowProvider.Object;
+            sut.ToggleValueProvider = fakeToggleValueProvider.Object;
+
+            Assert.IsTrue(sut.FeatureEnabled);
+        }
+
+        private class MyEnabledOnOrBeforeDateFeatureToggle : EnabledOnOrBeforeDateFeatureToggle { }
+    }  
+}

--- a/src/FeatureToggleSolution/Tests/FeatureToggle.Tests/FeatureToggle.Tests.csproj
+++ b/src/FeatureToggleSolution/Tests/FeatureToggle.Tests/FeatureToggle.Tests.csproj
@@ -59,8 +59,12 @@
   <ItemGroup>
     <Compile Include="AlwaysOnFeatureToggleTests.cs" />
     <Compile Include="AlwaysOffFeatureToggleTests.cs" />
+    <Compile Include="EnabledBetweenDatesFeatureToggleTests.cs" />
+    <Compile Include="EnabledOnOrAfterDateFeatureToggleTests.cs" />
+    <Compile Include="EnabledOnOrBeforeDateFeatureToggleTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SimpleFeatureToggleTests.cs" />
+    <Compile Include="SqlFeatureToggleTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\FeatureToggle\FeatureToggle.csproj">

--- a/src/FeatureToggleSolution/Tests/FeatureToggle.Tests/SqlFeatureToggleTests.cs
+++ b/src/FeatureToggleSolution/Tests/FeatureToggle.Tests/SqlFeatureToggleTests.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace JasonRoberts.FeatureToggle.Tests
+{
+    [TestClass]
+    public class SqlFeatureToggleTests
+    {
+        [TestMethod]
+        public void ShouldDisableFeatureWhenToggleValueIsFalse()
+        {
+            var fakeProvider = new Mock<IBooleanToggleValueProvider>();
+
+            fakeProvider.Setup(x => x.EvaluateBooleanToggleValue(It.IsAny<SqlFeatureToggle>())).Returns(false);
+
+            var sut = new MySqlFeatureToggle();
+            sut.ToggleValueProvider = fakeProvider.Object;
+
+            Assert.IsFalse(sut.FeatureEnabled);
+        }
+
+        [TestMethod]
+        public void ShouldEnableFeatureWhenToggleValueIsTrue()
+        {
+            var fakeProvider = new Mock<IBooleanToggleValueProvider>();
+
+            fakeProvider.Setup(x => x.EvaluateBooleanToggleValue(It.IsAny<SqlFeatureToggle>())).Returns(true);
+
+            var sut = new MySqlFeatureToggle();
+            sut.ToggleValueProvider = fakeProvider.Object;
+
+            Assert.IsTrue(sut.FeatureEnabled);
+        }
+
+        private class MySqlFeatureToggle : SqlFeatureToggle { }
+    }  
+}


### PR DESCRIPTION
Add unit tests for:

EnabledBetweenDatesFeatureToggle
EnabledOnOrAfterDateFeatureToggle
EnabledOnOrBeforeDateFeatureToggle
SqlFeatureToggle

There is some crossover with existing integration tests, but I believe that there is still value in testing these units in isolation from the config file.
