### PR TITLE
Add CLSCompliant attribute

### DIFF
--- a/src/FeatureToggleSolution/SharedAssemblyInfo.cs
+++ b/src/FeatureToggleSolution/SharedAssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyProduct("FeatureToggle")]
-[assembly: AssemblyCopyright("Copyright � Jason Roberts 2011")]
+[assembly: AssemblyCopyright("Copyright © Jason Roberts 2011")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 


### PR DESCRIPTION
In order for CLS compliant code to use this library, it also needs to be CLS compliant. The actual code already is compliant, it just doesn't have the attribute that lets other code know about it.
