### PR TITLE
Handled a ConnectionStringName in the BooleanSQLServerProvider class to prevent duplicated connection strings

### DIFF
--- a/src/FeatureToggle.Shared/Providers/BooleanSqlServerProvider.cs
+++ b/src/FeatureToggle.Shared/Providers/BooleanSqlServerProvider.cs
@@ -29,12 +29,32 @@ namespace FeatureToggle.Providers
         private string GetConnectionStringFromConfig(IFeatureToggle toggle)
         {
             var toggleNameInConfig = ToggleConfigurationSettings.Prefix + toggle.GetType().Name + ".ConnectionString";
+            var toggleConnectionNameInConfig = ToggleConfigurationSettings.Prefix + toggle.GetType().Name + ".ConnectionStringName";
 
-            if (!ConfigurationManager.AppSettings.AllKeys.Contains(toggleNameInConfig))
-                throw new ToggleConfigurationError(string.Format("The key '{0}' was not found in AppSettings",
-                                                                     toggleNameInConfig));
+            //Check if either a ConnectionString or a ConnectionStringName exists
+            if (!ConfigurationManager.AppSettings.AllKeys.Contains(toggleNameInConfig) && !ConfigurationManager.AppSettings.AllKeys.Contains(toggleConnectionNameInConfig))
+                throw new ToggleConfigurationError(string.Format("The key '{0}' or '{1}' was not found in AppSettings",
+                                                                     toggleNameInConfig, 
+                                                                     toggleConnectionNameInConfig));
 
-            return ConfigurationManager.AppSettings[toggleNameInConfig];
+            string connectionString;
+            //Use the ConnectionStringName if it's given
+            if(ConfigurationManager.AppSettings.AllKeys.Contains(toggleConnectionNameInConfig))
+            {
+                string connectionStringName = ConfigurationManager.AppSettings[toggleConnectionNameInConfig];
+                ConnectionStringSettings connectionStringSettings = ConfigurationManager.ConnectionStrings[connectionStringName];
+                if (connectionStringSettings == null || string.IsNullOrEmpty(connectionStringSettings.ConnectionString))
+                    throw new ToggleConfigurationError(string.Format("The connectionString with Key '{0}' was not found or is empty in the web.config file.",
+                                                                     connectionStringName));
+                connectionString = connectionStringSettings.ConnectionString;
+            }
+            else
+            {
+                connectionString = ConfigurationManager.AppSettings[toggleNameInConfig];
+            }
+
+
+            return connectionString;
         }
 
         private string GetCommandTextFromAppConfig(IFeatureToggle toggle)


### PR DESCRIPTION
Hi,
the BooleanSqlServerProvider now checks if there is either a ConnectionString or a ConnectionStringName given in the web.config. If it is the new ConnectionStringName, it uses the connection from the ConnectionString Area in the web.config with the given name.
Would be nice to be updated in the next version :)
Thanks