### PR TITLE
ApplyOnceFeatureToggle

### DIFF
--- a/src/FeatureToggle.Shared/FeatureToggle.Shared.projitems
+++ b/src/FeatureToggle.Shared/FeatureToggle.Shared.projitems
@@ -13,6 +13,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Providers\AppSettingsProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Providers\BooleanSqlServerProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Providers\JsonEnabledResponse.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Toggles\ApplyOnceFeatureToggle.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Toggles\ApplyOncePerAppFeatureToggle.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Toggles\ApplyOncePerUserFeatureToggle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Toggles\EnabledBetweenDatesFeatureToggle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Toggles\EnabledOnDaysOfWeekFeatureToggle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Toggles\EnabledOnOrAfterDateFeatureToggle.cs" />

--- a/src/FeatureToggle.Shared/Toggles/ApplyOnceFeatureToggle.cs
+++ b/src/FeatureToggle.Shared/Toggles/ApplyOnceFeatureToggle.cs
@@ -7,7 +7,7 @@ namespace FeatureToggle.Toggles
     /// <summary>
     /// This toggle is activated only one time, it could be created at any time
     /// </summary>
-    public class ApplyOnceFeatureToggle : IFeatureToggle
+    public abstract class ApplyOnceFeatureToggle : IFeatureToggle
     {
         public bool FeatureEnabled { get; private set; }
 

--- a/src/FeatureToggle.Shared/Toggles/ApplyOnceFeatureToggle.cs
+++ b/src/FeatureToggle.Shared/Toggles/ApplyOnceFeatureToggle.cs
@@ -1,0 +1,24 @@
+﻿using FeatureToggle.Core;
+
+// ReSharper disable CheckNamespace
+namespace FeatureToggle.Toggles
+// ReSharper restore CheckNamespace
+{
+    /// <summary>
+    /// This toggle is activated only one time, it could be created at any time
+    /// </summary>
+    public class ApplyOnceFeatureToggle : IFeatureToggle
+    {
+        public bool FeatureEnabled { get; private set; }
+
+
+        /// <summary>
+        /// Apply the use of the toggle (if it was enabled, disable it)
+        /// </summary>
+        public void Apply()
+        {
+            if (FeatureEnabled)
+                FeatureEnabled = false;
+        }
+    }
+}

--- a/src/FeatureToggle.Shared/Toggles/ApplyOncePerAppFeatureToggle.cs
+++ b/src/FeatureToggle.Shared/Toggles/ApplyOncePerAppFeatureToggle.cs
@@ -1,0 +1,43 @@
+﻿#if NETFX_CORE || WINDOWS_PHONE
+using Windows.Storage;
+using FeatureToggle.Core;
+
+// ReSharper disable CheckNamespace
+namespace FeatureToggle.Toggles
+// ReSharper restore CheckNamespace
+{
+    /// <summary>
+    /// This toggle is activated only one time per app, 
+    /// Retrieve toggle through Local Settings
+    /// </summary>
+    public class ApplyOncePerAppFeatureToggle : IFeatureToggle
+    {
+        // BUG : Local Settings are remove when app is removed (save in Roaming with device ID ?)
+        public bool FeatureEnabled
+        {
+            get
+            {
+                if (ApplicationData.Current.LocalSettings.Values.ContainsKey(Name))
+                    return (bool)ApplicationData.Current.LocalSettings.Values[Name];
+                return true;
+            }
+            private set
+            {
+                ApplicationData.Current.LocalSettings.Values[Name] = value;
+            }
+        }
+
+        public string Name { get; private set; }
+
+
+        /// <summary>
+        /// Apply the use of the toggle (if it was enabled, disable it)
+        /// </summary>
+        public virtual void Apply()
+        {
+            if (FeatureEnabled)
+                FeatureEnabled = false;
+        }
+    }
+}
+#endif

--- a/src/FeatureToggle.Shared/Toggles/ApplyOncePerAppFeatureToggle.cs
+++ b/src/FeatureToggle.Shared/Toggles/ApplyOncePerAppFeatureToggle.cs
@@ -10,7 +10,7 @@ namespace FeatureToggle.Toggles
     /// This toggle is activated only one time per app, 
     /// Retrieve toggle through Local Settings
     /// </summary>
-    public class ApplyOncePerAppFeatureToggle : IFeatureToggle
+    public abstract class ApplyOncePerAppFeatureToggle : IFeatureToggle
     {
         // BUG : Local Settings are remove when app is removed (save in Roaming with device ID ?)
         public bool FeatureEnabled

--- a/src/FeatureToggle.Shared/Toggles/ApplyOncePerUserFeatureToggle.cs
+++ b/src/FeatureToggle.Shared/Toggles/ApplyOncePerUserFeatureToggle.cs
@@ -11,7 +11,7 @@ namespace FeatureToggle.Toggles
     /// Example : Explains how the app works only one time (no matter how many devices user have)
     /// Retrieve toggle through Roaming Settings
     /// </summary>
-    public class ApplyOncePerUserFeatureToggle : IFeatureToggle
+    public abstract class ApplyOncePerUserFeatureToggle : IFeatureToggle
     {
         public bool FeatureEnabled
         {

--- a/src/FeatureToggle.Shared/Toggles/ApplyOncePerUserFeatureToggle.cs
+++ b/src/FeatureToggle.Shared/Toggles/ApplyOncePerUserFeatureToggle.cs
@@ -1,0 +1,43 @@
+﻿#if NETFX_CORE || WINDOWS_PHONE
+using Windows.Storage;
+using FeatureToggle.Core;
+
+// ReSharper disable CheckNamespace
+namespace FeatureToggle.Toggles
+// ReSharper restore CheckNamespace
+{
+    /// <summary>
+    /// This toggle is activated only one time per user, per all device family of the user
+    /// Example : Explains how the app works only one time (no matter how many devices user have)
+    /// Retrieve toggle through Roaming Settings
+    /// </summary>
+    public class ApplyOncePerUserFeatureToggle : IFeatureToggle
+    {
+        public bool FeatureEnabled
+        {
+            get
+            {
+                if (ApplicationData.Current.RoamingSettings.Values.ContainsKey(Name))
+                    return (bool)ApplicationData.Current.RoamingSettings.Values[Name];
+                return true;
+            }
+            private set
+            {
+                ApplicationData.Current.RoamingSettings.Values[Name] = value;
+            }
+        }
+
+        public string Name { get; private set; }
+
+
+        /// <summary>
+        /// Apply the use of the toggle (if it was enabled, disable it)
+        /// </summary>
+        public virtual void Apply()
+        {
+            if (FeatureEnabled)
+                FeatureEnabled = false;
+        }
+    }
+}
+#endif


### PR DESCRIPTION
This PR references the issue #86 about the ApplyOnceFeatureToggle.

I created 3 new FeatureToggle
- ApplyOnce - created and used at any time in session app
- ApplyOncePerApp - created and used only one time per app (each time you install the app in a newx device, the toggle is reset)
- ApplyOncePerUser - created and used only one time per user (no matter how many devices user have)
