### PR TITLE
Allow user to specify name of existing connection string for SqlFeatureToggle

### DIFF
--- a/src/Tests/FeatureToggle.Integration.Tests/App.config
+++ b/src/Tests/FeatureToggle.Integration.Tests/App.config
@@ -18,12 +18,15 @@
     <add key="FeatureToggle.MissingAppSettingsSqlStatementSqlServerToggle.ConnectionString" value="Data Source=.\SQLEXPRESS;Initial Catalog=FeatureToggleIntegrationTests;Integrated Security=True;Pooling=False" />    
     <add key="FeatureToggle.MissingAppSettingsSqlStatementKeySqlServerToggle.ConnectionString" value="Data Source=.\SQLEXPRESS;Initial Catalog=FeatureToggleIntegrationTests;Integrated Security=True;Pooling=False" />                                
     <add key="FeatureToggle.EmptyAppSettingsConnectionStringValueSqlServerToggle.ConnectionString" value="   " />
+    <add key="FeatureToggle.EmptyAppSettingsConnectionStringNameValueSqlServerToggle.ConnectionStringName" value="   " />
     <add key="FeatureToggle.EmptyAppSettingsSqlStatementValueSqlServerToggle.SqlStatement" value="   " />
     <add key="FeatureToggle.DuplicatedConfigSqlServerToggle.ConnectionString" value="Data Source=.\SQLEXPRESS;Initial Catalog=FeatureToggleIntegrationTests;Integrated Security=True;Pooling=False" />
     <add key="FeatureToggle.DuplicatedConfigSqlServerToggle.SqlStatement" value="select Value from Toggles where ToggleName = 'MySqlServerToggleFalse'" />
-    
-    
-    <!-- sql toggles -->
+    <add key="FeatureToggle.NameDoesNotExistInConnectionStringsSqlServerToggle.ConnectionStringName" value="MissingName" />
+    <add key="FeatureToggle.ConnectionStringConfiguredByNameSqlServerToggle.ConnectionStringName" value="EmptyConnectionString"/>
+
+
+      <!-- sql toggles -->
     <add key="FeatureToggle.MySqlServerToggleTrue.ConnectionString" value="Data Source=.\SQLEXPRESS;Initial Catalog=FeatureToggleIntegrationTests;Integrated Security=True;Pooling=False" />
     <add key="FeatureToggle.MySqlServerToggleTrue.SqlStatement" value="select Value from Toggles where ToggleName = 'MySqlServerToggleTrue'" />    
     <!-- Connection string for this toggle is in <connectionStrings> config element -->
@@ -60,6 +63,7 @@
     <!--SQL Server error-->
     <add name="FeatureToggle.EmptyConnectionStringsConnectionStringValueSqlServerToggle" connectionString="  " />    
     <add name="FeatureToggle.DuplicatedConfigSqlServerToggle" connectionString="Data Source=.\SQLEXPRESS;Initial Catalog=FeatureToggleIntegrationTests;Integrated Security=True;Pooling=False" />
+    <add name="EmptyConnectionString" connectionString="  " />
   </connectionStrings>
   
   <startup>

--- a/src/Tests/FeatureToggle.Integration.Tests/BooleanSqlServerProviderShould.cs
+++ b/src/Tests/FeatureToggle.Integration.Tests/BooleanSqlServerProviderShould.cs
@@ -5,13 +5,13 @@ using Shouldly;
 using Xunit;
 
 namespace FeatureToggle.Integration.Tests
-{    
+{
     public class BooleanSqlServerProviderShould
     {
         [Fact]
-        [Trait("category", "LocalIntegrationResourcesRequired")]                
+        [Trait("category", "LocalIntegrationResourcesRequired")]
         public void ReadBooleanTrueFromSqlServer()
-        {            
+        {
             var sut = new BooleanSqlServerProvider();
 
             var toggle = new MySqlServerToggleTrue();
@@ -33,13 +33,13 @@ namespace FeatureToggle.Integration.Tests
 
 
         [Fact]
-        public void ErrorWhenConnectionStringDoesntExistInAppSettingsNorConnectionStringsSections()
+        public void ErrorWhenConnectionStringIsNotConfigured()
         {
             var sut = new MissingConnectionStringSqlServerToggle();
 
             var ex = Assert.Throws<ToggleConfigurationError>(() => sut.FeatureEnabled);
 
-            ex.Message.ShouldBe("The connection string was not found in <appSettings> with a key of 'FeatureToggle.MissingConnectionStringSqlServerToggle.ConnectionString' or in <connectionStrings> with a name of 'FeatureToggle.MissingConnectionStringSqlServerToggle'.");
+            ex.Message.ShouldBe("The connection string was not configured in <appSettings> with a key of 'FeatureToggle.MissingConnectionStringSqlServerToggle.ConnectionString' or 'FeatureToggle.MissingConnectionStringSqlServerToggle.ConnectionStringName' nor in <connectionStrings> with a name of 'FeatureToggle.MissingConnectionStringSqlServerToggle'.");
         }
 
 
@@ -55,13 +55,24 @@ namespace FeatureToggle.Integration.Tests
 
 
         [Fact]
+        public void ErrorWhenAppSettingsConnectionStringNameValueIsEmpty()
+        {
+            var sut = new EmptyAppSettingsConnectionStringNameValueSqlServerToggle();
+
+            var ex = Assert.Throws<ToggleConfigurationError>(() => sut.FeatureEnabled);
+
+            ex.Message.ShouldBe("The <appSettings> value for key 'FeatureToggle.EmptyAppSettingsConnectionStringNameValueSqlServerToggle.ConnectionStringName' is empty.");
+        }
+
+
+        [Fact]
         public void ErrorWhenConnectionStringsConnectionStringIsEmpty()
         {
             var sut = new EmptyConnectionStringsConnectionStringValueSqlServerToggle();
 
             var ex = Assert.Throws<ToggleConfigurationError>(() => sut.FeatureEnabled);
 
-            ex.Message.ShouldBe("The <connectionStrings> value for connected named 'FeatureToggle.EmptyConnectionStringsConnectionStringValueSqlServerToggle' is empty.");
+            ex.Message.ShouldBe("The <connectionStrings> value for connection named 'FeatureToggle.EmptyConnectionStringsConnectionStringValueSqlServerToggle' is empty.");
         }
 
 
@@ -94,23 +105,47 @@ namespace FeatureToggle.Integration.Tests
 
             var ex = Assert.Throws<ToggleConfigurationError>(() => sut.FeatureEnabled);
 
-            ex.Message.ShouldBe("The connection string for 'FeatureToggle.DuplicatedConfigSqlServerToggle' is specified in both <appSettings> and <connectionStrings>.");
+            ex.Message.ShouldBe("The connection string for 'FeatureToggle.DuplicatedConfigSqlServerToggle' is configured multiple times.");
         }
 
 
-        
-   
+        [Fact]
+        public void ErrorWhenConnectionStringNameConfiguredInAppSettingsButNoEntryInConnectionStrings()
+        {
+            var sut = new NameDoesNotExistInConnectionStringsSqlServerToggle();
 
-        private class MySqlServerToggleTrue : SqlFeatureToggle{}
+            var ex = Assert.Throws<ToggleConfigurationError>(() => sut.FeatureEnabled);
+
+            ex.Message.ShouldBe("No entry named 'MissingName' exists in <connectionStrings>.");
+        }
+
+
+        [Fact]
+        public void ErrorWhenEntryInConnectionStringsButConnectionStringIsWhitespace()
+        {
+            var sut = new ConnectionStringConfiguredByNameSqlServerToggle();
+
+            var ex = Assert.Throws<ToggleConfigurationError>(() => sut.FeatureEnabled);
+
+            ex.Message.ShouldBe("The <connectionStrings> value for connection named 'EmptyConnectionString' is empty.");
+        }
+
+
+        private class MySqlServerToggleTrue : SqlFeatureToggle { }
         private class MySqlServerToggleFalse : SqlFeatureToggle { }
 
         private class MissingConnectionStringSqlServerToggle : SqlFeatureToggle { }
         private class MissingAppSettingsSqlStatementKeySqlServerToggle : SqlFeatureToggle { }
 
         private class EmptyAppSettingsConnectionStringValueSqlServerToggle : SqlFeatureToggle { }
+        private class EmptyAppSettingsConnectionStringNameValueSqlServerToggle : SqlFeatureToggle { }
         private class EmptyConnectionStringsConnectionStringValueSqlServerToggle : SqlFeatureToggle { }
         private class EmptyAppSettingsSqlStatementValueSqlServerToggle : SqlFeatureToggle { }
-        
+
         private class DuplicatedConfigSqlServerToggle : SqlFeatureToggle { }
+
+        private class NameDoesNotExistInConnectionStringsSqlServerToggle : SqlFeatureToggle { }
+
+        private class ConnectionStringConfiguredByNameSqlServerToggle : SqlFeatureToggle { }
     }
 }


### PR DESCRIPTION
The connection string can now be specified three ways...

Entirely in &lt;appSettings&gt; (existing functionality):

    <appSettings>
        <add key="FeatureToggle.MyFeatureToggle.ConnectionString" value="Data Source=..." />
    </appSettings>

Entirely in &lt;connectionStrings&gt; (existing functionality as of 3.1):

    <connectionStrings>    
        <add name="FeatureToggle.MySqlServerToggleFalse" connectionString="Data Source=..." />    
    </connectionStrings>	

By specifying name of existing connection string in &lt;connectionStrings&gt; in the &lt;appSettings&gt; (new functionality):

    <connectionStrings>
        <add name="primary" connectionString="Data Source=..." />
    </connectionStrings>

    <appSettings>
        <add key="FeatureToggle.MyFeatureToggle.ConnectionStringName" value="primary" />
    </appSettings>
