### PR TITLE
Fix Convention tests that were failing because of compiler-generated …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ obj/
 [Dd]ebug*/
 [Rr]elease*/
 Ankh.NoLoad
+*.vs
 
 #Tooling
 _ReSharper*/

--- a/src/Tests/FeatureToggle.Tests/ConventionTests/ToggleConventionTests.cs
+++ b/src/Tests/FeatureToggle.Tests/ConventionTests/ToggleConventionTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
+using ApprovalUtilities.Utilities;
 using FeatureToggle.Toggles;
 using TestStack.ConventionTests;
 using TestStack.ConventionTests.ConventionData;
@@ -14,10 +16,10 @@ namespace FeatureToggle.Tests.ConventionTests
         [Fact]
         public void TogglesInCorrectNamespace()
         {
-            var typesToCheck = Types.InAssemblyOf<SimpleFeatureToggle>();           
+            var typesToCheck = Types.InAssemblyOf<SimpleFeatureToggle>("NonNested", types=>types.Where(t=>!t.IsNestedPrivate));     
+            
 
-            Convention.Is(new ClassTypeHasSpecificNamespace(
-                x => x.Name.EndsWith("Toggle"),
+            Convention.Is(new ClassTypeHasSpecificNamespace(x=> x.Name.EndsWith("Toggle"),
                 TogglesNamespace,
                 "Toggle Base Classes"), typesToCheck);
         }

--- a/src/Tests/FeatureToggle.Tests/ConventionTests/TypeIsAbstractConvention.cs
+++ b/src/Tests/FeatureToggle.Tests/ConventionTests/TypeIsAbstractConvention.cs
@@ -8,7 +8,7 @@ namespace FeatureToggle.Tests.ConventionTests
     {
         public void Execute(Types data, IConventionResultContext result)
         {
-            var invalidTypes = data.TypesToVerify.Where(type => !type.IsAbstract).ToList();
+            var invalidTypes = data.TypesToVerify.Where(type =>!type.IsNestedPrivate && !type.IsAbstract).ToList();
 
             result.Is("Types should be abstract", invalidTypes);
         }


### PR DESCRIPTION
…nested inner classes.

When I cloned and tried to run tests, I noticed that a couple Unit Tests were failing because of some nested inner classes that the compiler generates.  This fixes those tests.