### PR TITLE
Convert .net core to .net standard

### DIFF
--- a/src/FeatureToggle.Shared/Internal/AppSettingsProvider.cs
+++ b/src/FeatureToggle.Shared/Internal/AppSettingsProvider.cs
@@ -1,4 +1,4 @@
-﻿#if NETFULL || NETCORE
+﻿#if NETFULL || NETSTANDARD
 
 using System;
 using System.Collections.Generic;
@@ -12,7 +12,7 @@ using System.Configuration;
 using System.Web.Script.Serialization;
 #endif
 
-#if NETCORE
+#if NETSTANDARD
 using Microsoft.Extensions.Configuration;
 using System.IO;
 #endif
@@ -25,7 +25,7 @@ namespace FeatureToggle.Internal
         private const string KeyNotFoundInAppsettingsMessage = "The key '{0}' was not found in AppSettings";
 
 
-#if NETCORE
+#if NETSTANDARD
         
         IConfigurationRoot _configuration;
 
@@ -235,7 +235,7 @@ namespace FeatureToggle.Internal
         }
 
 
-#if NETCORE
+#if NETSTANDARD
         private static string AppDirectory  => AppContext.BaseDirectory;
 #endif
 

--- a/src/FeatureToggle/FeatureToggle.csproj
+++ b/src/FeatureToggle/FeatureToggle.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <DefaultLanguage>en-US</DefaultLanguage>
-    <TargetFrameworks>net461;uap10.0;netcoreapp1.0;</TargetFrameworks>
+    <TargetFrameworks>net461;uap10.0;netstandard1.4;</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Version>4.0.2</Version>
@@ -18,13 +18,14 @@
     <PackageReleaseNotes>For release notes and history see https://github.com/jason-roberts/FeatureToggle/blob/master/Release-Notes.md</PackageReleaseNotes>
   </PropertyGroup>
   
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
-    <DefineConstants>NETCORE;NETCOREAPP1_0</DefineConstants>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
+    <DefineConstants>NETSTANDARD</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">    
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">    
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.1" />
+    <PackageReference Include="System.Net.Requests" Version="4.3.0" />
   </ItemGroup>
 
 

--- a/src/Tests/FeatureToggle.NetCore.Tests/FeatureToggle.NetCore.Tests.csproj
+++ b/src/Tests/FeatureToggle.NetCore.Tests/FeatureToggle.NetCore.Tests.csproj
@@ -6,11 +6,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DefineConstants>TRACE;DEBUG;NETCOREAPP1_0;NETCORE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NETSTANDARD</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DefineConstants>TRACE;RELEASE;NETCOREAPP1_0;NETCORE</DefineConstants>
+    <DefineConstants>TRACE;RELEASE;NETSTANDARD</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/FeatureToggle.NetCore.Tests/SolutionPathUtility.cs
+++ b/src/Tests/FeatureToggle.NetCore.Tests/SolutionPathUtility.cs
@@ -1,4 +1,4 @@
-﻿#if NETCORE
+﻿#if NETSTANDARD
 
 using System;
 using System.IO;

--- a/src/Tests/FeatureToggle.NetCore/FeatureToggle.NetCore.csproj
+++ b/src/Tests/FeatureToggle.NetCore/FeatureToggle.NetCore.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DefineConstants>TRACE;DEBUG;NETCOREAPP1_0;NETCORE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NETSTANDARD</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DefineConstants>TRACE;RELEASE;NETCOREAPP1_0;NETCORE</DefineConstants>
+    <DefineConstants>TRACE;RELEASE;NETSTANDARD</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/FeatureToggle.Shared.Tests/EnabledBetweenDatesFeatureToggleShould.cs
+++ b/src/Tests/FeatureToggle.Shared.Tests/EnabledBetweenDatesFeatureToggleShould.cs
@@ -1,4 +1,4 @@
-﻿#if NETFULL || NETCORE // no Moq support in UWP test projects
+﻿#if NETFULL || NETSTANDARD // no Moq support in UWP test projects
 
 using System;
 using FeatureToggle;

--- a/src/Tests/FeatureToggle.Shared.Tests/EnabledOnDaysOfWeekFeatureToggleShould.cs
+++ b/src/Tests/FeatureToggle.Shared.Tests/EnabledOnDaysOfWeekFeatureToggleShould.cs
@@ -1,4 +1,4 @@
-﻿#if NETFULL || NETCORE // no Moq support in UWP test projects
+﻿#if NETFULL || NETSTANDARD // no Moq support in UWP test projects
 
 using System;
 using FeatureToggle;

--- a/src/Tests/FeatureToggle.Shared.Tests/EnabledOnOrAfterDateFeatureToggleShould.cs
+++ b/src/Tests/FeatureToggle.Shared.Tests/EnabledOnOrAfterDateFeatureToggleShould.cs
@@ -1,4 +1,4 @@
-﻿#if NETFULL || NETCORE // no Moq support in UWP test projects
+﻿#if NETFULL || NETSTANDARD // no Moq support in UWP test projects
 
 using System;
 using FeatureToggle;

--- a/src/Tests/FeatureToggle.Shared.Tests/Integration/AppSettingsProviderBooleanShould.cs
+++ b/src/Tests/FeatureToggle.Shared.Tests/Integration/AppSettingsProviderBooleanShould.cs
@@ -1,4 +1,4 @@
-﻿#if NETFULL || NETCORE
+﻿#if NETFULL || NETSTANDARD
 
 using System;
 using FeatureToggle;

--- a/src/Tests/FeatureToggle.Shared.Tests/Integration/AppSettingsProviderDateTimeShould.cs
+++ b/src/Tests/FeatureToggle.Shared.Tests/Integration/AppSettingsProviderDateTimeShould.cs
@@ -1,4 +1,4 @@
-﻿#if NETFULL || NETCORE
+﻿#if NETFULL || NETSTANDARD
 
 using System;
 //using System.Configuration;

--- a/src/Tests/FeatureToggle.Shared.Tests/Integration/AppSettingsProviderForDaysOfWeekShould.cs
+++ b/src/Tests/FeatureToggle.Shared.Tests/Integration/AppSettingsProviderForDaysOfWeekShould.cs
@@ -1,4 +1,4 @@
-﻿#if NETFULL || NETCORE
+﻿#if NETFULL || NETSTANDARD
 
 using System;
 using System.Linq;
@@ -28,7 +28,7 @@ namespace FeatureToggle.Shared.Tests.Integration
             var sut = new AppSettingsProvider();
 
             var ex = Assert.Throws<ToggleConfigurationError>(() => sut.GetDaysOfWeek(new InvalidDayToggle()).ToList());
-#if NETCORE
+#if NETSTANDARD
             Assert.Equal("The value 'Sun' in config key 'InvalidDayToggle' is not a valid day of the week. Days should be specified in long format. E.g. Friday and not Fri.", ex.Message);
 #else
             Assert.Equal("The value 'Sun' in config key 'FeatureToggle.InvalidDayToggle' is not a valid day of the week. Days should be specified in long format. E.g. Friday and not Fri.", ex.Message);

--- a/src/Tests/FeatureToggle.Shared.Tests/Integration/AppSettingsProviderTimePeriodShould.cs
+++ b/src/Tests/FeatureToggle.Shared.Tests/Integration/AppSettingsProviderTimePeriodShould.cs
@@ -1,4 +1,4 @@
-﻿#if NETFULL || NETCORE
+﻿#if NETFULL || NETSTANDARD
 
 
 using System;
@@ -31,7 +31,7 @@ namespace FeatureToggle.Shared.Tests.Integration
                 () =>
                     new AppSettingsProvider().EvaluateTimePeriod(
                         new FormatInConfigIsWrong()));
-#if NETCORE
+#if NETSTANDARD
             Assert.Equal(
                 "The value '02/01/2050 04:05:44' cannot be converted to a DateTime as defined in config key 'FormatInConfigIsWrong'. The expected format is: dd-MMM-yyyy HH:mm:ss",
                 ex.Message);

--- a/src/Tests/FeatureToggle.Shared.Tests/SimpleFeatureToggleShould.cs
+++ b/src/Tests/FeatureToggle.Shared.Tests/SimpleFeatureToggleShould.cs
@@ -3,7 +3,7 @@ using FeatureToggle;
 using FeatureToggle.Internal;
 using Xunit;
 
-#if NETFULL || NETCORE
+#if NETFULL || NETSTANDARD
 using Moq;
 #endif
 
@@ -15,14 +15,14 @@ namespace FeatureToggle.Tests
         public void HaveDefaultProvider()
         {
             var sut = new MySimpleFeatureToggle();
-#if NETFULL || NETCORE
+#if NETFULL || NETSTANDARD
             Assert.Equal(typeof(AppSettingsProvider), sut.ToggleValueProvider.GetType());
 #else
             Assert.Equal(typeof(ApplicationResourcesSettingsProvider), sut.ToggleValueProvider.GetType());
 #endif
         }
 
-#if NETFULL || NETCORE // can't Moq in UWP
+#if NETFULL || NETSTANDARD // can't Moq in UWP
         [Fact]
         public void SetOptionalProviderOnCreation()
         {


### PR DESCRIPTION
Hi Jason,

I am trying to convert some project libraries to .Net standard 2.0. The problem is that this is not possible for the libraries using FeatureToggle. While FeatureToggle supports .Net core,  you cannot use these within a .Net standard project.

I created this PR whereby I converted the .Net Core FeatureToggle library to .Net standard.

Maybe you can have a look at it and if possible publish a new version? 